### PR TITLE
Pass first window via createWidget

### DIFF
--- a/app/widgets/com.orthlieb.navigationgroup/controllers/widget.js
+++ b/app/widgets/com.orthlieb.navigationgroup/controllers/widget.js
@@ -1,3 +1,5 @@
+var args = arguments[0] || {};
+
 // Originally derived from example code from Appcelerator developer relations.
 $.windowStack = [];
 
@@ -105,3 +107,7 @@ Object.defineProperty($, "length", {
         return $.windowStack.length; 
     }
 });
+
+if (args.window) {
+    exports.open(args.window);
+}


### PR DESCRIPTION
This change allows for:

```
Alloy.Globals.stack = Alloy.createWidget('com.orthlieb.navigationgroup', {
    window: $.index
});
```
